### PR TITLE
Add CODEOWNERS for GitHub

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 *   @KimTaehee
+*   @nakaldi


### PR DESCRIPTION
> Code owners are automatically requested for review when someone opens a pull request that modifies code that they own.

Ref.: https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners#about-code-owners
